### PR TITLE
 更新雷神评分规则

### DIFF
--- a/resources/meta-gs/character/雷电将军/artis.js
+++ b/resources/meta-gs/character/雷电将军/artis.js
@@ -3,8 +3,14 @@ export default function ({ attr, weapon, rule, def }) {
   if (attr.mastery > 500) {
     return rule('雷神-精通', { atk: 75, cpct: 90, cdmg: 90, mastery: 100, dmg: 75, recharge: 90 })
   }
-  if (weapon.name === '薙草之稻光' && weapon.affix >= 3) {
-    return rule('雷神-高精', { atk: 90, cpct: 100, cdmg: 100, dmg: 90, recharge: 90 })
+  if (weapon.name === '薙草之稻光' && weapon.affix >= 3 && attr.recharge <= 250) {
+    return rule('雷神-高精1', { atk: 75, cpct: 100, cdmg: 100, dmg: 75, recharge: 100 })
+  }
+  if (weapon.name === '薙草之稻光' && weapon.affix >= 3 && attr.recharge > 250 && attr.recharge <= 264) {
+    return rule('雷神-高精2', { atk: 75, cpct: 100, cdmg: 100, dmg: 75, recharge: 75 })
+  }  
+  if (weapon.name === '薙草之稻光' && weapon.affix >= 3 && attr.recharge > 264) {
+    return rule('雷神-高精3', { atk: 75, cpct: 100, cdmg: 100, dmg: 75, recharge: 55 })
   }
   return def({ atk: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 75, recharge: 90 })
 }


### PR DESCRIPTION
雷神高精且开Q充能不超过300时，一个充能词条约等于一个双爆词条；若充能超过300但小于314（精5薙刀阈值），一个充能词条约等于一个攻击词条；充能超过314，则一个充能词条小于一个攻击词条。

对雷神而言，攻击恒小于双爆。高精时充能会转换成巨量攻击力导致攻击词条大贬值，所以攻击权重不应过高。高精雷神攻击区和增伤区相差不大，且现在雷神有很多不带攻击拐的队伍，所以攻击和增伤的权重应该保持一致。低精雷神和非专武雷神相对而言充能不容易溢出且攻击区不够爆炸，故不作讨论。